### PR TITLE
add default storeid

### DIFF
--- a/code/Block/Adminhtml/Dashboard.php
+++ b/code/Block/Adminhtml/Dashboard.php
@@ -78,7 +78,7 @@ class Clerk_Clerk_Block_Adminhtml_Dashboard extends Mage_Adminhtml_Block_Templat
      */
     public function getStoreId()
     {
-        return $this->getRequest()->getParam('store');
+        return $this->getRequest()->getParam('store') ? $this->getRequest()->getParam('store') : Mage::app()->getDefaultStoreView()->getId();
     }
 
     /**


### PR DESCRIPTION
if there is only one store select to choose store not appear, so you are unable to view reports
with this fix is set correctly to default store_id and i can view dashboard reports but others embended urls like search return 404 :
https://my.clerk.io/#/store/storeid_part/analytics/search?key=clerk_public_key&private_key=clerk_private_key&embed=yes